### PR TITLE
set HOME environment

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -33,7 +33,7 @@
 
 PATH=/usr/bin:/bin
 LINTFLAGS="--fail-on-warnings --no-autoloader_layout-check"
-
+export HOME=/
 REPOS="$1"
 TXN="$2"
 TMPFILE=`mktemp`


### PR DESCRIPTION
In Puppet 3 the puppet parser validate command will throw an error with 'Error: Could not intialize global default settings: couldn't find HOME environment -- expanding `~/.puppet'' if the HOME variable is not set, and fail on valid manifests. This pull request exports HOME to / which sorts it.

Cheers //Johan
